### PR TITLE
Fix nullability of GetChars() in System.Data

### DIFF
--- a/Annotations/.NETFramework/System.Data/2.0.0.0.Nullness.Gen.xml
+++ b/Annotations/.NETFramework/System.Data/2.0.0.0.Nullness.Gen.xml
@@ -5384,7 +5384,7 @@
   </member>
   <member name="M:System.Data.Common.DbDataReader.GetChars(System.Int32,System.Int64,System.Char[],System.Int32,System.Int32)">
     <parameter name="buffer">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Data.Common.DbDataReader.GetData(System.Int32)">
@@ -14401,7 +14401,7 @@
   </member>
   <member name="M:System.Data.SqlClient.SqlDataReader.GetChars(System.Int32,System.Int64,System.Char[],System.Int32,System.Int32)">
     <parameter name="buffer">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Data.SqlClient.SqlDataReader.GetDataTypeNameInternal(System.Data.SqlClient._SqlMetaData)">

--- a/Annotations/.NETFramework/System.Data/4.0.0.0.Nullness.Gen.xml
+++ b/Annotations/.NETFramework/System.Data/4.0.0.0.Nullness.Gen.xml
@@ -958,7 +958,7 @@
   </member>
   <member name="M:System.Data.Common.DbDataReader.GetChars(System.Int32,System.Int64,System.Char[],System.Int32,System.Int32)">
     <parameter name="buffer">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Data.Common.DbDataReader.GetData(System.Int32)">
@@ -2295,7 +2295,7 @@
   </member>
   <member name="M:System.Data.IDataRecord.GetChars(System.Int32,System.Int64,System.Char[],System.Int32,System.Int32)">
     <parameter name="buffer">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Data.IDataRecord.GetData(System.Int32)">
@@ -3266,7 +3266,7 @@
   </member>
   <member name="M:System.Data.SqlClient.SqlDataReader.GetChars(System.Int32,System.Int64,System.Char[],System.Int32,System.Int32)">
     <parameter name="buffer">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Data.SqlClient.SqlDataReader.GetEnumerator">


### PR DESCRIPTION
DbDataReader.GetChars() and friends allow the buffer parameter to be null - this simply returns the length.

https://msdn.microsoft.com/en-us/library/system.data.sqlclient.sqldatareader.getchars(v=vs.110).aspx

I originally opened [RSRP-429112](https://youtrack.jetbrains.com/issue/RSRP-429112) back in 2014, hopefully this PR gets more attention :)