### PR TITLE
System.IO.Directory.Exists(System.String) NotNull -> CanBeNull

### DIFF
--- a/Annotations/.NETFramework/mscorlib/4.0.0.0.Contracts.xml
+++ b/Annotations/.NETFramework/mscorlib/4.0.0.0.Contracts.xml
@@ -1661,7 +1661,7 @@
   </member>
   <member name="M:System.IO.Directory.Exists(System.String)">
     <parameter name="path">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.IO.Directory.GetCreationTime(System.String)">


### PR DESCRIPTION
`null` is valid and returns `false`, see http://referencesource.microsoft.com/#mscorlib/system/io/directory.cs,6a2a3bee6b62826f

`               if (path == null)
                    return false;
                if (path.Length == 0)
                    return false;
`