### PR TITLE
Fix annotation for Path.GetDirectoryName

### DIFF
--- a/Annotations/.NETFramework/mscorlib/ContractAnnotations.xml
+++ b/Annotations/.NETFramework/mscorlib/ContractAnnotations.xml
@@ -20,11 +20,6 @@
       <argument>path:notnull =&gt; notnull</argument>
     </attribute>
   </member>
-  <member name="M:System.IO.Path.GetDirectoryName(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
-      <argument>path:notnull =&gt; notnull</argument>
-    </attribute>
-  </member>
   <member name="M:System.IO.Path.ChangeExtension(System.String,System.String)">
     <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
       <argument>path:notnull =&gt; notnull</argument>


### PR DESCRIPTION
Path.GetDirectoryName("C:/") returns "null"