### PR TITLE
System.Type.GetProperties, System.Type.GetProperty can return null

### DIFF
--- a/Annotations/.NETFramework/mscorlib/2.0.0.0.Contracts.xml
+++ b/Annotations/.NETFramework/mscorlib/2.0.0.0.Contracts.xml
@@ -3338,14 +3338,16 @@
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperties(System.Reflection.BindingFlags)">
-    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperty(System.String)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type[])">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
@@ -3354,11 +3356,13 @@
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Reflection.BindingFlags)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
@@ -3367,6 +3371,7 @@
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type,System.Type[])">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>

--- a/Annotations/.NETFramework/mscorlib/2.0.5.0.Contracts.xml
+++ b/Annotations/.NETFramework/mscorlib/2.0.5.0.Contracts.xml
@@ -2172,19 +2172,22 @@
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperties(System.Reflection.BindingFlags)">
-    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperty(System.String)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Reflection.BindingFlags)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
@@ -2193,6 +2196,7 @@
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type,System.Type[])">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>

--- a/Annotations/.NETFramework/mscorlib/4.0.0.0.Contracts.xml
+++ b/Annotations/.NETFramework/mscorlib/4.0.0.0.Contracts.xml
@@ -3416,14 +3416,16 @@
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperties(System.Reflection.BindingFlags)">
-    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperty(System.String)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type[])">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
@@ -3432,11 +3434,13 @@
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Reflection.BindingFlags)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
@@ -3445,6 +3449,7 @@
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type,System.Type[])">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>


### PR DESCRIPTION
[RSRP-463823](https://youtrack.jetbrains.com/issue/RSRP-463823):  System.Type.GetProperties(flags) can return  null