### PR TITLE
CanBeNull attribute for XElement.Attribute

### DIFF
--- a/Annotations/.NETCore/System.Xml.XDocument/4.0.0.0.Nullness.xml
+++ b/Annotations/.NETCore/System.Xml.XDocument/4.0.0.0.Nullness.xml
@@ -32,7 +32,7 @@
     <parameter name="source">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
-  </member>
+  </member> 
   <member name="M:System.Xml.Linq.Extensions.DescendantNodes``1(System.Collections.Generic.IEnumerable{``0})">
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     <parameter name="source">
@@ -253,6 +253,9 @@
   </member>
   <member name="M:System.Xml.Linq.XElement.Attributes">
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+  </member>
+  <member name="M:System.Xml.Linq.XElement.Attribute(System.Xml.Linq.XName)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
   </member>
   <member name="M:System.Xml.Linq.XElement.DescendantNodesAndSelf">
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />


### PR DESCRIPTION
[RSRP-438204](https://youtrack.jetbrains.com/issue/RSRP-438204) CanBeNull annotation for XElement.Attribute