### PR TITLE
Revert "System.Type.GetProperties, System.Type.GetProperty can return null"

### DIFF
--- a/Annotations/.NETFramework/mscorlib/2.0.0.0.Contracts.xml
+++ b/Annotations/.NETFramework/mscorlib/2.0.0.0.Contracts.xml
@@ -3338,16 +3338,14 @@
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperties(System.Reflection.BindingFlags)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperty(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type[])">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
@@ -3356,13 +3354,11 @@
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Reflection.BindingFlags)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
@@ -3371,7 +3367,6 @@
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type,System.Type[])">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>

--- a/Annotations/.NETFramework/mscorlib/2.0.5.0.Contracts.xml
+++ b/Annotations/.NETFramework/mscorlib/2.0.5.0.Contracts.xml
@@ -2172,22 +2172,19 @@
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperties(System.Reflection.BindingFlags)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperty(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Reflection.BindingFlags)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
@@ -2196,7 +2193,6 @@
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type,System.Type[])">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>

--- a/Annotations/.NETFramework/mscorlib/4.0.0.0.Contracts.xml
+++ b/Annotations/.NETFramework/mscorlib/4.0.0.0.Contracts.xml
@@ -3416,16 +3416,14 @@
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperties(System.Reflection.BindingFlags)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperty(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type[])">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
@@ -3434,13 +3432,11 @@
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Reflection.BindingFlags)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
@@ -3449,7 +3445,6 @@
     </parameter>
   </member>
   <member name="M:System.Type.GetProperty(System.String,System.Type,System.Type[])">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="name">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>


### PR DESCRIPTION
public virtual PropertyInfo[] GetProperties(BindingFlags arg0)
Returns:
    //     An array of System.Reflection.PropertyInfo objects representing all properties
    //     of the current System.Type that match the specified binding constraints.-or-
    //     An empty array of type System.Reflection.PropertyInfo, if the current System.Type
    //     does not have properties, or if none of the properties match the binding
    //     constraints.

So the change for GetProperties is wrong!