### PR TITLE
	NotNull for System.Type.GetProperties(BindingFlags)

### DIFF
--- a/Annotations/.NETFramework/mscorlib/2.0.0.0.Contracts.xml
+++ b/Annotations/.NETFramework/mscorlib/2.0.0.0.Contracts.xml
@@ -3338,7 +3338,7 @@
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperties(System.Reflection.BindingFlags)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperty(System.String)">
     <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />

--- a/Annotations/.NETFramework/mscorlib/2.0.5.0.Contracts.xml
+++ b/Annotations/.NETFramework/mscorlib/2.0.5.0.Contracts.xml
@@ -2172,7 +2172,7 @@
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperties(System.Reflection.BindingFlags)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperty(System.String)">
     <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />

--- a/Annotations/.NETFramework/mscorlib/4.0.0.0.Contracts.xml
+++ b/Annotations/.NETFramework/mscorlib/4.0.0.0.Contracts.xml
@@ -3416,7 +3416,7 @@
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperties(System.Reflection.BindingFlags)">
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
   </member>
   <member name="M:System.Type.GetProperty(System.String)">
     <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />


### PR DESCRIPTION
Make "NotNull" attribute for System.Type.GetProperties(BindingFlags). Details: #66