### PR TITLE
Wrong async method annotation

### DIFF
--- a/Annotations/Misc/xUnit.net/xunit.core.xml
+++ b/Annotations/Misc/xUnit.net/xunit.core.xml
@@ -42,7 +42,7 @@
 
   <member name="M:Xunit.Record.ExceptionAsync(System.Func{System.Threading.Tasks.Task})">
     <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor" />
-    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.ItemCanBeNullAttribute.#ctor" />
     <attribute ctor="M:JetBrains.Annotations.MustUseReturnValueAttribute.#ctor" />
     <parameter name="testCode">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />


### PR DESCRIPTION
Looks like it was simply copy&pasted from non-async `Exception()` method