### PR TITLE
added Caliburn.Micro Set method annotation

### DIFF
--- a/Annotations/Misc/Caliburn.Micro/Attributes.xml
+++ b/Annotations/Misc/Caliburn.Micro/Attributes.xml
@@ -7,6 +7,9 @@
     <attribute ctor="M:JetBrains.Annotations.NotifyPropertyChangedInvocatorAttribute.#ctor" />
   </member>
   <member name="M:Caliburn.Micro.PropertyChangedBase.RaisePropertyChangedEventImmediately(System.String)">
-	<attribute ctor="M:JetBrains.Annotations.NotifyPropertyChangedInvocatorAttribute.#ctor" />
+    <attribute ctor="M:JetBrains.Annotations.NotifyPropertyChangedInvocatorAttribute.#ctor" />
+  </member>
+  <member name="M:Caliburn.Micro.PropertyChangedBase.Set``1(``0@,``0,System.String)">
+    <attribute ctor="M:JetBrains.Annotations.NotifyPropertyChangedInvocatorAttribute.#ctor(System.String)"><argument>propertyName</argument></attribute>
   </member>
 </assembly>


### PR DESCRIPTION
fixes #149 

I tested this set of annotations locally against Caliburn.Micro 3.2.0, and the Set method appeared correctly:

![image](https://user-images.githubusercontent.com/12620443/50229812-2cdb3380-0379-11e9-9b0c-4a6ea020c9a6.png)