### PR TITLE
Ninject: Parameter can be Null

### DIFF
--- a/Annotations/Misc/Ninject/Ninject.xml
+++ b/Annotations/Misc/Ninject/Ninject.xml
@@ -816,7 +816,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
     <parameter name="target">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
   </member>
   <member name="M:Ninject.Parameters.Parameter.#ctor(System.String,System.Func{Ninject.Activation.IContext,Ninject.Planning.Targets.ITarget,System.Object},System.Boolean)">


### PR DESCRIPTION
Ninject: Second parameter of IParameter.GetValue(IContext, ITarget) can be Null