### PR TITLE
HttpRouteValueDictionary - Fix false positive "Content of collection '...' is never updated" warning

### DIFF
--- a/Annotations/.NETFramework/System.Web.Http/Annotations.xml
+++ b/Annotations/.NETFramework/System.Web.Http/Annotations.xml
@@ -9,7 +9,8 @@
     <attribute ctor="M:JetBrains.Annotations.CollectionAccessAttribute.#ctor(JetBrains.Annotations.CollectionAccessType)">
       <argument>6</argument> <!-- APPEND -->
     </attribute>
-  </member>  <member name="M:System.Web.Http.Routing.UrlHelper.Route(System.String,System.Object)">
+  </member>
+  <member name="M:System.Web.Http.Routing.UrlHelper.Route(System.String,System.Object)">
     <parameter name="routeValues">
       <attribute ctor="M:JetBrains.Annotations.AspMvcActionAttribute.#ctor(System.String)">
         <argument>Action</argument>

--- a/Annotations/.NETFramework/System.Web.Http/Annotations.xml
+++ b/Annotations/.NETFramework/System.Web.Http/Annotations.xml
@@ -5,8 +5,11 @@
       <argument>1</argument>
     </attribute>
   </member>
-
-  <member name="M:System.Web.Http.Routing.UrlHelper.Route(System.String,System.Object)">
+  <member name="M:System.Web.Http.Routing.HttpRouteValueDictionary.#ctor(System.Object)">
+    <attribute ctor="M:JetBrains.Annotations.CollectionAccessAttribute.#ctor(JetBrains.Annotations.CollectionAccessType)">
+      <argument>6</argument> <!-- APPEND -->
+    </attribute>
+  </member>  <member name="M:System.Web.Http.Routing.UrlHelper.Route(System.String,System.Object)">
     <parameter name="routeValues">
       <attribute ctor="M:JetBrains.Annotations.AspMvcActionAttribute.#ctor(System.String)">
         <argument>Action</argument>


### PR DESCRIPTION
Add [CollectionAccess(CollectionAccessType.ModifyExistingContent)] attribute to the System.Web.Http.Routing.HttpRouteValueDictionary(object values) constructor to prevent the "Content of collection '...' is never updated" warning, since that constructor will (generally) populate the dictionary with items.