### PR TITLE
Add more Microsoft.Extensions annotations

### DIFF
--- a/Annotations/.NETCore/Microsoft.Extensions.Hosting.Abstractions/Attributes.xml
+++ b/Annotations/.NETCore/Microsoft.Extensions.Hosting.Abstractions/Attributes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly name="Microsoft.Extensions.Hosting.Abstractions">
+  <member name="M:Microsoft.Extensions.DependencyInjection.ServiceCollectionHostedServiceExtensions.AddHostedService``1(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+    <typeparameter name="THostedService">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags)">
+        <argument>8</argument>
+      </attribute>  
+    </typeparameter>
+  </member>
+</assembly>

--- a/Annotations/.NETCore/Microsoft.Extensions.Options/Attributes.xml
+++ b/Annotations/.NETCore/Microsoft.Extensions.Options/Attributes.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly name="Microsoft.Extensions.Options">
+  <member name="M:Microsoft.Extensions.DependencyInjection.OptionsServiceCollectionExtensions.AddOptions``1(Microsoft.Extensions.DependencyInjection.IServiceCollection)">
+    <typeparameter name="TOptions">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags)">
+        <argument>8</argument>
+      </attribute>  
+    </typeparameter>
+  </member>
+</assembly>

--- a/Annotations/.NETCore/Microsoft.Extensions.Options/Attributes.xml
+++ b/Annotations/.NETCore/Microsoft.Extensions.Options/Attributes.xml
@@ -7,4 +7,11 @@
       </attribute>  
     </typeparameter>
   </member>
+  <member name="M:Microsoft.Extensions.DependencyInjection.OptionsServiceCollectionExtensions.AddOptions``1(Microsoft.Extensions.DependencyInjection.IServiceCollection, System.String)">
+    <typeparameter name="TOptions">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags)">
+        <argument>8</argument>
+      </attribute>  
+    </typeparameter>
+  </member>
 </assembly>


### PR DESCRIPTION
Added `MeansImplicitUse` annotations for more `IServiceCollection` extension methods

- Microsoft.Extensions.Hosting.Abstractions
  - `IServiceCollection.AddHostedService<THostedService>`
- Microsoft.Extensions.Options
  - `IServiceCollection.AddOptions<TOptions>`