### PR TITLE
Add annotations for Should method for FluentAssertions

### DIFF
--- a/Annotations/Misc/FluentAssertions/Annotations.xml
+++ b/Annotations/Misc/FluentAssertions/Annotations.xml
@@ -1,0 +1,277 @@
+﻿<assembly name="FluentAssertions">
+  <member name="M:FluentAssertions.AssertionExtensions.Should(FluentAssertions.Specialized.ExecutionTime)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Reflection.Assembly)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Xml.Linq.XDocument)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Xml.Linq.XElement)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Xml.Linq.XAttribute)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Object)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Boolean)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.Boolean})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Guid)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.Guid})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Collections.IEnumerable)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should``1(System.Collections.Generic.IEnumerable{``0})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Collections.Generic.IEnumerable{System.String})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should``2(System.Collections.Generic.IDictionary{``0,``1})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.DateTime)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.DateTimeOffset)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.DateTime})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.DateTimeOffset})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should``1(System.IComparable`1{``0})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Int32)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.Int32})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.UInt32)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.UInt32})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Decimal)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.Decimal})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Byte)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.Byte})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.SByte)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.SByte})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Int16)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.Int16})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.UInt16)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.UInt16})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Int64)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.Int64})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.UInt64)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.UInt64})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Single)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.Single})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Double)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.Double})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.String)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.TimeSpan)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Nullable{System.TimeSpan})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Type)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(FluentAssertions.Types.TypeSelector)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Reflection.ConstructorInfo)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Reflection.MethodInfo)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(FluentAssertions.Types.MethodInfoSelector)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Reflection.PropertyInfo)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(FluentAssertions.Types.PropertyInfoSelector)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Action)">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should(System.Func{System.Threading.Tasks.Task})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should``1(System.Func{System.Threading.Tasks.Task{``0}})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+  <member name="M:FluentAssertions.AssertionExtensions.Should``1(System.Func`1{``0})">
+    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
+      <argument>null=>halt</argument>
+    </attribute>
+  </member>
+</assembly>


### PR DESCRIPTION
This pull request relates to https://github.com/JetBrains/ExternalAnnotations/issues/164.

This annotations supresses warning in this case

```
sut.Should().NotBeNull();
sut.Description.Should().Be(expectedDescription);
```

Although method `.Should()` actualy not throw any exception such annotations is reasonable.
Code that don't use the result of the following expression `something.Should()` is wrong, because `.Should()` is a pure method. You may use the result of the `something.Should()` expression in two ways: 

- first one is null expectation, like `something.Should().BeNull()`, so there is no reason to assert something else
- second one is non-null expectation - this is any assertion that somehow assert value, for example `new[] {1, 2}.Should().HaveCount(2)`. In this case two outcomes possible: assertion fails, and no following code executes; assertion passes so `something` is definitely not null.