### PR TITLE
The newValue of a StringBuilder.Replace can be null

### DIFF
--- a/Annotations/.NETFramework/mscorlib/Annotations.xml
+++ b/Annotations/.NETFramework/mscorlib/Annotations.xml
@@ -4139,7 +4139,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
     <parameter name="newValue">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor"/>
     </parameter>
   </member>
   <member name="M:System.Text.StringBuilder.Replace(System.Char,System.Char,System.Int32,System.Int32)">


### PR DESCRIPTION
StringBuilder's Replace(string,string) is perfectly content with a null for the newValue parameter.