### PR TITLE
CanBeNull for assemblyName for System.Activator.CreateInstance

### DIFF
--- a/Annotations/.NETCore/System.Private.CoreLib/Attributes.xml
+++ b/Annotations/.NETCore/System.Private.CoreLib/Attributes.xml
@@ -1190,7 +1190,7 @@
   </member>
   <member name="M:System.Activator.CreateInstance(System.String,System.String)">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
@@ -1211,7 +1211,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
@@ -1219,7 +1219,7 @@
   </member>
   <member name="M:System.Activator.CreateInstance(System.String,System.String,System.Object[])">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
@@ -1242,7 +1242,7 @@
   </member>
   <member name="M:System.Activator.CreateInstance(System.String,System.String,System.Boolean,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[],System.Security.Policy.Evidence)">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
@@ -1253,7 +1253,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
@@ -8161,7 +8161,7 @@
   </member>
   <member name="M:System.Activator.CreateInstance(System.String,System.String,System.Boolean,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[])">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
@@ -8191,7 +8191,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>

--- a/Annotations/.NETCore/System.Runtime/Annotations.xml
+++ b/Annotations/.NETCore/System.Runtime/Annotations.xml
@@ -1250,7 +1250,7 @@
   </member>
   <member name ="M:System.Activator.CreateInstance(System.String,System.String)">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -1281,7 +1281,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -1299,7 +1299,7 @@
   </member>
   <member name ="M:System.Activator.CreateInstance(System.String,System.String,System.Object[])">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -1332,7 +1332,7 @@
   </member>
   <member name ="M:System.Activator.CreateInstance(System.String,System.String,System.Boolean,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[],System.Security.Policy.Evidence)">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -1353,7 +1353,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -4596,7 +4596,7 @@
   </member>
   <member name ="M:System.Activator.CreateInstance(System.String,System.String,System.Boolean,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[])">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -4626,7 +4626,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />

--- a/Annotations/.NETFramework/mscorlib/Annotations.xml
+++ b/Annotations/.NETFramework/mscorlib/Annotations.xml
@@ -1008,7 +1008,7 @@
   </member>
   <member name="M:System.Activator.CreateInstance(System.String,System.String)">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
@@ -1029,7 +1029,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
@@ -1037,7 +1037,7 @@
   </member>
   <member name="M:System.Activator.CreateInstance(System.String,System.String,System.Object[])">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
@@ -1060,7 +1060,7 @@
   </member>
   <member name="M:System.Activator.CreateInstance(System.String,System.String,System.Boolean,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[],System.Security.Policy.Evidence)">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
@@ -1071,7 +1071,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
@@ -34551,7 +34551,7 @@
   </member>
   <member name="M:System.Activator.CreateInstance(System.String,System.String,System.Boolean,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[])">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
@@ -34618,7 +34618,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>

--- a/Annotations/.NETStandard/netstandard/Annotations.xml
+++ b/Annotations/.NETStandard/netstandard/Annotations.xml
@@ -33205,7 +33205,7 @@
   </member>
   <member name ="M:System.Activator.CreateInstance(System.String,System.String)">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -33236,7 +33236,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -33254,7 +33254,7 @@
   </member>
   <member name ="M:System.Activator.CreateInstance(System.String,System.String,System.Object[])">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -33287,7 +33287,7 @@
   </member>
   <member name ="M:System.Activator.CreateInstance(System.String,System.String,System.Boolean,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[],System.Security.Policy.Evidence)">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -33308,7 +33308,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -38852,7 +38852,7 @@
   </member>
   <member name ="M:System.Activator.CreateInstance(System.String,System.String,System.Boolean,System.Reflection.BindingFlags,System.Reflection.Binder,System.Object[],System.Globalization.CultureInfo,System.Object[])">
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
@@ -38882,7 +38882,7 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
     <parameter name="assemblyName">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
     <parameter name="typeName">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />


### PR DESCRIPTION

According to the official doc: https://docs.microsoft.com/en-us/dotnet/api/system.activator.createinstance
For all overloads of the `Activator.CreateInstance()` method, the `string assemblyName` parameter can be `null`.

> If `assemblyName` is `null`, the executing assembly is searched.

This is true for all versions (.NET 5, .NET Core, .NET Framework).

----

Source code also says so:
https://github.com/dotnet/runtime/blob/11cd2721a9bb3fe0c21e20979a3e670f61e3507d/src/libraries/System.Private.CoreLib/src/System/Activator.RuntimeType.cs#L120-L123