### PR TITLE
Nullable attributes for System.IO.Directory.GetParent

### DIFF
--- a/Annotations/.NETCore/System.Private.CoreLib/Attributes.xml
+++ b/Annotations/.NETCore/System.Private.CoreLib/Attributes.xml
@@ -11692,8 +11692,9 @@
     </parameter>
   </member>
   <member name="M:System.IO.Directory.GetParent(System.String)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor"/>
     <parameter name="path">
-      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
   </member>
   <member name="M:System.IO.Directory.Move(System.String,System.String)">

--- a/Annotations/.NETFramework/mscorlib/Annotations.xml
+++ b/Annotations/.NETFramework/mscorlib/Annotations.xml
@@ -2633,8 +2633,9 @@
     <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
   </member>
   <member name="M:System.IO.Directory.GetParent(System.String)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor"/>
     <parameter name="path">
-      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor"/>
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
   </member>
   <member name="M:System.IO.Directory.Move(System.String,System.String)">

--- a/Annotations/.NETStandard/netstandard/Annotations.xml
+++ b/Annotations/.NETStandard/netstandard/Annotations.xml
@@ -45622,8 +45622,9 @@
     </parameter>
   </member>
   <member name ="M:System.IO.Directory.GetParent(System.String)">
+    <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     <parameter name="path">
-      <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
+      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
     <parameter name="path">
       <attribute ctor="M:JetBrains.Annotations.LocalizationRequiredAttribute.#ctor(System.Boolean)">


### PR DESCRIPTION
- NotNull for input parameter "path"
> Exceptions - ArgumentNullException - path is null

- CanBeNull for return value
> Returns - null if path is the root directory

Reference: https://docs.microsoft.com/en-us/dotnet/api/system.io.directory.getparent