### PR TITLE
Add UsedImplicitly to Storyteller Fixture

### DIFF
--- a/Annotations/Misc/Storyteller/Storyteller.xml
+++ b/Annotations/Misc/Storyteller/Storyteller.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8" ?> 
+<assembly name="Storyteller">
+
+    <member name="T:StoryTeller.Fixture">
+        <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+            <argument>7</argument>
+        </attribute>
+    </member>
+
+</assembly>


### PR DESCRIPTION
In [Storyteller](https://storyteller.github.io/), `Fixture` classes are used to dynamically compose tests (defined in Markdown files).