### PR TITLE
Add MeansImplicitUse for Dapper

### DIFF
--- a/Annotations/Misc/Dapper/SqlMapper.Async.MeansImplicitUseAttribute.xml
+++ b/Annotations/Misc/Dapper/SqlMapper.Async.MeansImplicitUseAttribute.xml
@@ -176,4 +176,354 @@
       </attribute>
     </typeparameter>
   </member>
+
+  <!-- MultiMap -->
+  <member name="M:Dapper.SqlMapper.QueryAsync``3(System.Data.IDbConnection,System.String,System.Func{``0,``1,``2},System.Object,System.Data.IDbTransaction,System.Boolean,System.String,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync``3(System.Data.IDbConnection,Dapper.CommandDefinition,System.Func{``0,``1,``2},System.String)">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync``4(System.Data.IDbConnection,System.String,System.Func{``0,``1,``2,``3},System.Object,System.Data.IDbTransaction,System.Boolean,System.String,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync``4(System.Data.IDbConnection,Dapper.CommandDefinition,System.Func{``0,``1,``2,``3},System.String)">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync``5(System.Data.IDbConnection,System.String,System.Func{``0,``1,``2,``3,``4},System.Object,System.Data.IDbTransaction,System.Boolean,System.String,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFourth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync``5(System.Data.IDbConnection,Dapper.CommandDefinition,System.Func{``0,``1,``2,``3,``4},System.String)">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFourth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync``6(System.Data.IDbConnection,System.String,System.Func{``0,``1,``2,``3,``4,``5},System.Object,System.Data.IDbTransaction,System.Boolean,System.String,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFourth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFifth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync``6(System.Data.IDbConnection,Dapper.CommandDefinition,System.Func{``0,``1,``2,``3,``4,``5},System.String)">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFourth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFifth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync``7(System.Data.IDbConnection,System.String,System.Func{``0,``1,``2,``3,``4,``5,``6},System.Object,System.Data.IDbTransaction,System.Boolean,System.String,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFourth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFifth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSixth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync``7(System.Data.IDbConnection,Dapper.CommandDefinition,System.Func{``0,``1,``2,``3,``4,``5,``6},System.String)">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFourth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFifth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSixth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync``8(System.Data.IDbConnection,System.String,System.Func{``0,``1,``2,``3,``4,``5,``6,``7},System.Object,System.Data.IDbTransaction,System.Boolean,System.String,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFourth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFifth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSixth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSeventh">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync``8(System.Data.IDbConnection,Dapper.CommandDefinition,System.Func{``0,``1,``2,``3,``4,``5,``6,``7},System.String)">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFourth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFifth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSixth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSeventh">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
 </assembly>

--- a/Annotations/Misc/Dapper/SqlMapper.Async.MeansImplicitUseAttribute.xml
+++ b/Annotations/Misc/Dapper/SqlMapper.Async.MeansImplicitUseAttribute.xml
@@ -1,0 +1,179 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly name="Dapper">
+  <member name="M:Dapper.SqlMapper.QueryAsync``1(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync(System.Data.IDbConnection,System.Type,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync``1(System.Data.IDbConnection,Dapper.CommandDefinition)">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryAsync(System.Data.IDbConnection,System.Type,Dapper.CommandDefinition)">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirstAsync``1(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirstAsync(System.Data.IDbConnection,System.Type,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirstAsync``1(System.Data.IDbConnection,Dapper.CommandDefinition)">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirstAsync(System.Data.IDbConnection,System.Type,Dapper.CommandDefinition)">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirstOrDefaultAsync``1(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirstOrDefaultAsync(System.Data.IDbConnection,System.Type,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirstOrDefaultAsync``1(System.Data.IDbConnection,Dapper.CommandDefinition)">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirstOrDefaultAsync(System.Data.IDbConnection,System.Type,Dapper.CommandDefinition)">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingleAsync``1(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingleAsync(System.Data.IDbConnection,System.Type,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingleAsync``1(System.Data.IDbConnection,Dapper.CommandDefinition)">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingleAsync(System.Data.IDbConnection,System.Type,Dapper.CommandDefinition)">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingleOrDefaultAsync``1(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingleOrDefaultAsync(System.Data.IDbConnection,System.Type,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingleOrDefaultAsync``1(System.Data.IDbConnection,Dapper.CommandDefinition)">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingleOrDefaultAsync(System.Data.IDbConnection,System.Type,Dapper.CommandDefinition)">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.ExecuteScalarAsync``1(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.ExecuteScalarAsync``1(System.Data.IDbConnection,Dapper.CommandDefinition)">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+</assembly>

--- a/Annotations/Misc/Dapper/SqlMapper.MeansImplicitUseAttribute.xml
+++ b/Annotations/Misc/Dapper/SqlMapper.MeansImplicitUseAttribute.xml
@@ -136,4 +136,180 @@
       </attribute>
     </typeparameter>
   </member>
+
+  <!-- MultiMap -->
+  <member name="M:Dapper.SqlMapper.Query``3(System.Data.IDbConnection,System.String,System.Func{``0,``1,``2},System.Object,System.Data.IDbTransaction,System.Boolean,System.String,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.Query``4(System.Data.IDbConnection,System.String,System.Func{``0,``1,``2,``3},System.Object,System.Data.IDbTransaction,System.Boolean,System.String,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.Query``5(System.Data.IDbConnection,System.String,System.Func{``0,``1,``2,``3,``4},System.Object,System.Data.IDbTransaction,System.Boolean,System.String,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFourth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.Query``6(System.Data.IDbConnection,System.String,System.Func{``0,``1,``2,``3,``4,``5},System.Object,System.Data.IDbTransaction,System.Boolean,System.String,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFourth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFifth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.Query``7(System.Data.IDbConnection,System.String,System.Func{``0,``1,``2,``3,``4,``5,``6},System.Object,System.Data.IDbTransaction,System.Boolean,System.String,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFourth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFifth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSixth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.Query``8(System.Data.IDbConnection,System.String,System.Func{``0,``1,``2,``3,``4,``5,``6,``7},System.Object,System.Data.IDbTransaction,System.Boolean,System.String,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="TFirst">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSecond">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TThird">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFourth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TFifth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSixth">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+    <typeparameter name="TSeventh">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
 </assembly>

--- a/Annotations/Misc/Dapper/SqlMapper.MeansImplicitUseAttribute.xml
+++ b/Annotations/Misc/Dapper/SqlMapper.MeansImplicitUseAttribute.xml
@@ -1,0 +1,139 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly name="Dapper">
+  <member name="M:Dapper.SqlMapper.Query``1(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Boolean,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.Query``1(System.Data.IDbConnection,Dapper.CommandDefinition)">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.Query(System.Data.IDbConnection,System.Type,System.String,System.Object,System.Data.IDbTransaction,System.Boolean,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirst``1(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirst``1(System.Data.IDbConnection,Dapper.CommandDefinition)">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirst(System.Data.IDbConnection,System.Type,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirstOrDefault``1(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirstOrDefault``1(System.Data.IDbConnection,Dapper.CommandDefinition)">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QueryFirstOrDefault(System.Data.IDbConnection,System.Type,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingle``1(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingle``1(System.Data.IDbConnection,Dapper.CommandDefinition)">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingle(System.Data.IDbConnection,System.Type,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingleOrDefault``1(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingleOrDefault``1(System.Data.IDbConnection,Dapper.CommandDefinition)">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.QuerySingleOrDefault(System.Data.IDbConnection,System.Type,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <parameter name="type">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </parameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.ExecuteScalar``1(System.Data.IDbConnection,System.String,System.Object,System.Data.IDbTransaction,System.Nullable{System.Int32},System.Nullable{System.Data.CommandType})">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+  <member name="M:Dapper.SqlMapper.ExecuteScalar``1(System.Data.IDbConnection,Dapper.CommandDefinition)">
+    <typeparameter name="T">
+      <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor(JetBrains.Annotations.ImplicitUseKindFlags,JetBrains.Annotations.ImplicitUseTargetFlags)">
+        <argument>8</argument>
+        <argument>3</argument>
+      </attribute>
+    </typeparameter>
+  </member>
+</assembly>


### PR DESCRIPTION
This adds `MeansImplicitUse` for some of the most commonly used methods, all belonging to the class `SqlMapper` in [Dapper](https://www.nuget.org/packages/Dapper):

| sync | async |
| --- | --- |
| `Query()` | `QueryAsync()` |
| `QueryFirst()` | `QueryFirstAsync()` |
| `QueryFirstOrDefault()` | `QueryFirstOrDefaultAsync()` |
| `QuerySingle()` | `QuerySingleAsync()` |
| `QuerySingleOrDefault()` | `QuerySingleOrDefaultAsync()` |
| `ExecuteScalar()` | `ExecuteScalarAsync()` |

I tested the XMLs a bit locally in JetBrains Rider 2021.3 EAP 5 Build #RD-213.5281.17. Works fine.

Also, this should fix [RSRP-434975](https://youtrack.jetbrains.com/issue/RSRP-434975).