### PR TITLE
Remove incorrect [NotNull] annotation from Array.BinarySearch 'value' parameter, fixes RSRP-488379

### DIFF
--- a/Annotations/.NETFramework/mscorlib/Annotations.xml
+++ b/Annotations/.NETFramework/mscorlib/Annotations.xml
@@ -1250,15 +1250,9 @@
     <parameter name="array">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
-    <parameter name="value">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
-    </parameter>
   </member>
   <member name="M:System.Array.BinarySearch(System.Array,System.Object,System.Collections.IComparer)">
     <parameter name="array">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
-    </parameter>
-    <parameter name="value">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
   </member>
@@ -1266,15 +1260,9 @@
     <parameter name="array">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
-    <parameter name="value">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
-    </parameter>
   </member>
   <member name="M:System.Array.BinarySearch(System.Array,System.Int32,System.Int32,System.Object,System.Collections.IComparer)">
     <parameter name="array">
-      <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
-    </parameter>
-    <parameter name="value">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
   </member>


### PR DESCRIPTION
Remove incorrect [NotNull] annotation from Array.BinarySearch 'value' parameter, fixes RSRP-488379