### PR TITLE
NUnit annotations for Datapoints

### DIFF
--- a/Annotations/Misc/NUnit.Framework/Attributes.xml
+++ b/Annotations/Misc/NUnit.Framework/Attributes.xml
@@ -370,7 +370,10 @@
   <member name="T:NUnit.Framework.CombiningStrategyAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
-  <member name="T:NUnit.Framework.DataPointAttribute">
+  <member name="T:NUnit.Framework.DatapointAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
+  <member name="T:NUnit.Framework.DatapointsAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
   <member name="T:NUnit.Framework.DataPointSourceAttribute">


### PR DESCRIPTION
1. DatapointsAttribute means implicit used
2. There is not a single mention of DataPointAttribute in the history of nunit project. I guess it was a typo of DatapointAttribute.