### PR TITLE
Add MediatR

### DIFF
--- a/Annotations/Misc/MediatR/MediatR.xml
+++ b/Annotations/Misc/MediatR/MediatR.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly name="MediatR">
+  <member name="T:MediatR.INotificationHandler`1">
+    <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+      <argument>4</argument>
+    </attribute>
+  </member>
+  <member name="T:MediatR.IRequestHandler`2">
+    <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+      <argument>4</argument>
+    </attribute>
+  </member>
+  <member name="T:MediatR.IStreamRequestHandler`2">
+    <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+      <argument>4</argument>
+    </attribute>
+  </member>
+  <member name="T:MediatR.Pipeline.IRequestExceptionAction`2">
+    <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+      <argument>4</argument>
+    </attribute>
+  </member>
+  <member name="T:MediatR.Pipeline.IRequestExceptionHandler`3">
+    <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+      <argument>4</argument>
+    </attribute>
+  </member>
+  <member name="T:MediatR.Pipeline.IRequestPostProcessor`2">
+    <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+      <argument>4</argument>
+    </attribute>
+  </member>
+  <member name="T:MediatR.Pipeline.IRequestPreProcessor`1">
+    <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+      <argument>4</argument>
+    </attribute>
+  </member>
+</assembly>

--- a/Annotations/Misc/MediatR/MediatR.xml
+++ b/Annotations/Misc/MediatR/MediatR.xml
@@ -5,6 +5,11 @@
       <argument>4</argument>
     </attribute>
   </member>
+  <member name="T:MediatR.IRequestHandler`1">
+    <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+      <argument>4</argument>
+    </attribute>
+  </member>
   <member name="T:MediatR.IRequestHandler`2">
     <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
       <argument>4</argument>


### PR DESCRIPTION
Adds annotations for [MediatR](https://github.com/jbogard/MediatR), a widely used mediator library.

It marks as implicitly used all implementations of MediatR services implicitly added to the DI with `services.AddMediatR()`.