### PR TITLE
Remove irrelevant [StringFormatMethod]

### DIFF
--- a/Annotations/.NETCore/System.Console/Attributes.xml
+++ b/Annotations/.NETCore/System.Console/Attributes.xml
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <assembly name="System.Console">
-  <member name="M:System.Console.Write(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
-  </member>
   <member name="M:System.Console.Write(System.String,System.Object)">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
       <argument>format</argument>
@@ -41,11 +36,6 @@
     </parameter>
   </member>
   <member name="M:System.Console.Write(System.String,System.Object,System.Object,System.Object,System.Object)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
-  </member>
-  <member name="M:System.Console.WriteLine(System.String)">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
       <argument>format</argument>
     </attribute>

--- a/Annotations/.NETCore/System.Private.CoreLib/Attributes.xml
+++ b/Annotations/.NETCore/System.Private.CoreLib/Attributes.xml
@@ -78,9 +78,6 @@
     </parameter>
   </member>
   <member name="M:System.Diagnostics.Debug.Print(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
     <parameter name="message">
       <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor"/>
     </parameter>

--- a/Annotations/.NETCore/System.Runtime.Extensions/Attributes.xml
+++ b/Annotations/.NETCore/System.Runtime.Extensions/Attributes.xml
@@ -97,11 +97,6 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
   </member>
-  <member name="M:System.IO.TextWriter.WriteLine(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
-  </member>
   <member name="M:System.IO.TextWriter.WriteLine(System.String,System.Object)">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
       <argument>format</argument>
@@ -139,11 +134,6 @@
     <parameter name="format">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
-  </member>
-  <member name="M:System.IO.TextWriter.Write(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
   </member>
   <member name="M:System.IO.TextWriter.Write(System.String,System.Object)">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">

--- a/Annotations/.NETCore/System.Runtime/Attributes.xml
+++ b/Annotations/.NETCore/System.Runtime/Attributes.xml
@@ -57,9 +57,6 @@
     </parameter>
   </member>
   <member name="M:System.Diagnostics.Debug.Print(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
     <parameter name="message">
       <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor"/>
     </parameter>
@@ -240,11 +237,6 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
   </member>
-  <member name="M:System.IO.TextWriter.WriteLine(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
-  </member>
   <member name="M:System.IO.TextWriter.WriteLine(System.String,System.Object)">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
       <argument>format</argument>
@@ -282,11 +274,6 @@
     <parameter name="format">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
-  </member>
-  <member name="M:System.IO.TextWriter.Write(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
   </member>
   <member name="M:System.IO.TextWriter.Write(System.String,System.Object)">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">

--- a/Annotations/.NETFramework/System/Attributes.xml
+++ b/Annotations/.NETFramework/System/Attributes.xml
@@ -1,8 +1,5 @@
 <assembly name="System">
 
-  <member name="M:System.Diagnostics.Debug.Print(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
-  </member>
   <member name="M:System.Diagnostics.Debug.Print(System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)"><argument>format</argument></attribute>
   </member>

--- a/Annotations/.NETFramework/mscorlib/Annotations.xml
+++ b/Annotations/.NETFramework/mscorlib/Annotations.xml
@@ -176,11 +176,6 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
   </member>
-  <member name="M:System.IO.TextWriter.WriteLine(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
-  </member>
   <member name="M:System.IO.TextWriter.WriteLine(System.String,System.Object)">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
       <argument>format</argument>
@@ -218,11 +213,6 @@
     <parameter name="format">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
-  </member>
-  <member name="M:System.IO.TextWriter.Write(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
   </member>
   <member name="M:System.IO.TextWriter.Write(System.String,System.Object)">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
@@ -262,11 +252,6 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor"/>
     </parameter>
   </member>
-  <member name="M:System.Console.Write(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
-  </member>
   <member name="M:System.Console.Write(System.String,System.Object)">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
       <argument>format</argument>
@@ -303,11 +288,6 @@
     </parameter>
   </member>
   <member name="M:System.Console.Write(System.String,System.Object,System.Object,System.Object,System.Object)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
-  </member>
-  <member name="M:System.Console.WriteLine(System.String)">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
       <argument>format</argument>
     </attribute>

--- a/Annotations/.NETStandard/netstandard/Annotations.xml
+++ b/Annotations/.NETStandard/netstandard/Annotations.xml
@@ -5331,9 +5331,6 @@
     </parameter>
   </member>
   <member name ="M:System.Console.Write(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
     <attribute ctor="M:JetBrains.Annotations.LocalizationRequiredAttribute.#ctor(System.Boolean)">
       <argument>true</argument>
     </attribute>
@@ -5394,9 +5391,6 @@
     </attribute>
   </member>
   <member name ="M:System.Console.WriteLine(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
     <attribute ctor="M:JetBrains.Annotations.LocalizationRequiredAttribute.#ctor(System.Boolean)">
       <argument>true</argument>
     </attribute>
@@ -32607,9 +32601,6 @@
     </parameter>
   </member>
   <member name ="M:System.Diagnostics.Debug.Print(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
     <parameter name="message">
       <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
     </parameter>
@@ -73244,11 +73235,6 @@
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
   </member>
-  <member name ="M:System.IO.TextWriter.WriteLine(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
-  </member>
   <member name ="M:System.IO.TextWriter.WriteLine(System.String,System.Object)">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
       <argument>format</argument>
@@ -73272,11 +73258,6 @@
     <parameter name="format">
       <attribute ctor="M:JetBrains.Annotations.NotNullAttribute.#ctor" />
     </parameter>
-  </member>
-  <member name ="M:System.IO.TextWriter.Write(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>format</argument>
-    </attribute>
   </member>
   <member name ="M:System.IO.TextWriter.Write(System.String,System.Object)">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">

--- a/Annotations/Misc/xUnit.net/xunit.abstractions.xml
+++ b/Annotations/Misc/xUnit.net/xunit.abstractions.xml
@@ -1,9 +1,4 @@
 <assembly name="xunit.abstractions">
-  <member name="M:Xunit.Abstractions.ITestOutputHelper.WriteLine(System.String)">
-    <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
-      <argument>message</argument>
-    </attribute>
-  </member>
   <member name="M:Xunit.Abstractions.ITestOutputHelper.WriteLine(System.String,System.Object[])">
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
       <argument>format</argument>

--- a/JetBrains.ExternalAnnotations.nuspec
+++ b/JetBrains.ExternalAnnotations.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>JetBrains.ExternalAnnotations</id>
-    <version>10.2.130</version>
+    <version>10.2.131</version>
     <authors>JetBrains</authors>
     <owners>JetBrains</owners>
     <projectUrl>https://github.com/JetBrains/ExternalAnnotations</projectUrl>


### PR DESCRIPTION
* Remove attribute from `Console`, `Debug` and `TextWriter` method overloads with one parameter. In these cases argument name "format" was used and annotations had no effect.
* Remove annotation from `Xunit.Abstractions.ITestOutputHelper.WriteLine` overload of one string. This changes the behaviour to the actual one, since this overload does not use `string.Format` ([link](https://github.com/xunit/xunit/blob/b09dbc55ebadaf7ce7eca8584e04e4fc44257c25/src/xunit.v3.core/Sdk/Frameworks/TestOutputHelper.cs#L60))