### PR TITLE
Annotate DiagnosticAnalyzerAttribute and ExportCodeFixProviderAttribute

### DIFF
--- a/Annotations/Microsoft/Microsoft.CodeAnalysis.Workspaces/Attributes.xml
+++ b/Annotations/Microsoft/Microsoft.CodeAnalysis.Workspaces/Attributes.xml
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly name="Microsoft.CodeAnalysis.Workspaces">
+  <member name="T:Microsoft.CodeAnalysis.CodeFixes.ExportCodeFixProviderAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
+</assembly>

--- a/Annotations/Microsoft/Microsoft.CodeAnalysis/Attributes.xml
+++ b/Annotations/Microsoft/Microsoft.CodeAnalysis/Attributes.xml
@@ -3,4 +3,7 @@
   <member name="T:Microsoft.CodeAnalysis.GeneratorAttribute">
     <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
   </member>
+  <member name="T:Microsoft.CodeAnalysis.Diagnostics.DiagnosticAnalyzerAttribute">
+    <attribute ctor="M:JetBrains.Annotations.MeansImplicitUseAttribute.#ctor" />
+  </member>
 </assembly>


### PR DESCRIPTION
This PR annotates the `DiagnosticAnalyzerAttribute` and `ExportCodeFixProviderAttribute` with `MeansImplicitUseAttribute` to remove the warning about the types never being instantiated.
The attributes are used when creating Roslyn analyzers and code fixers, so it seems like the correct place to improve the annotations.