### PR TITLE
Mark EF6 DbMigration as UsedImplicitly

### DIFF
--- a/Annotations/Microsoft/EntityFramework/Attributes.xml
+++ b/Annotations/Microsoft/EntityFramework/Attributes.xml
@@ -1246,4 +1246,9 @@
   <member name="M:System.Data.Entity.QueryableExtensions.TryGetObjectQuery(System.Linq.IQueryable)">
     <attribute ctor="M:JetBrains.Annotations.CanBeNullAttribute.#ctor" />
   </member>
+  <member name="T:System.Data.Entity.Migrations.DbMigration">
+    <attribute ctor="M:JetBrains.Annotations.UsedImplicitlyAttribute.#ctor(JetBrains.Annotations.ImplicitUseTargetFlags)">
+      <argument>7</argument> <!-- ImplicitUseTargetFlags.Itself | ImplicitUseTargetFlags.Members | ImplicitUseTargetFlags.WithInheritors -->
+    </attribute>
+  </member>
 </assembly>


### PR DESCRIPTION
Since migrations are loaded via reflection, they should be marked as `UsedImplicitly`