### PR TITLE
Fix StringSyntaxAttribute constructor argument

### DIFF
--- a/Annotations/Microsoft/Microsoft.Extensions.Logging.Abstractions/StringSyntax.xml
+++ b/Annotations/Microsoft/Microsoft.Extensions.Logging.Abstractions/StringSyntax.xml
@@ -2,7 +2,7 @@
 <assembly name="Microsoft.Extensions.Logging.Abstractions">
   <member name="M:Microsoft.Extensions.Logging.LoggerMessageAttribute.#ctor(int,Microsoft.Extensions.Logging.LogLevel,System.String)">
     <parameter name="message">
-      <attribute ctor="M:System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.#ctor(System.String)(System.String)">
+      <attribute ctor="M:System.Diagnostics.CodeAnalysis.StringSyntaxAttribute.#ctor(System.String)">
         <argument>StructuredLogMessageTemplate</argument>
       </attribute>
     </parameter>


### PR DESCRIPTION
Argument list is duplicated, seems like a typo.