### PR TITLE
Remove ContractAnnotationAttribute for Unity Assertsion

### DIFF
--- a/Annotations/Unity/UnityEngine.xml
+++ b/Annotations/Unity/UnityEngine.xml
@@ -275,56 +275,12 @@
 
 
   <!-- UnityEngine.Debug -->
-  <member name="M:UnityEngine.Debug.Assert(System.Boolean)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
-    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
-      <argument>condition:false=&gt;halt</argument>
-    </attribute>
-  </member>
-  <member name="M:UnityEngine.Debug.Assert(System.Boolean,UnityEngine.Object)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
-    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
-      <argument>condition:false=&gt;halt</argument>
-    </attribute>
-  </member>
-  <member name="M:UnityEngine.Debug.Assert(System.Boolean,System.Object)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
-    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
-      <argument>condition:false=&gt;halt</argument>
-    </attribute>
-  </member>
-  <member name="M:UnityEngine.Debug.Assert(System.Boolean,System.String)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
-    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
-      <argument>condition:false=&gt;halt</argument>
-    </attribute>
-  </member>
-  <member name="M:UnityEngine.Debug.Assert(System.Boolean,System.Object,UnityEngine.Object)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
-    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
-      <argument>condition:false=&gt;halt</argument>
-    </attribute>
-  </member>
-  <member name="M:UnityEngine.Debug.Assert(System.Boolean,System.String,UnityEngine.Object)">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
-    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
-      <argument>condition:false=&gt;halt</argument>
-    </attribute>
-  </member>
   <member name="M:UnityEngine.Debug.AssertFormat(System.Boolean,System.String,System.Object[])">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
-    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
-      <argument>condition:false=&gt;halt</argument>
-    </attribute>
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
       <argument>format</argument>
     </attribute>
   </member>
   <member name="M:UnityEngine.Debug.AssertFormat(System.Boolean,UnityEngine.Object,System.String,System.Object[])">
-    <attribute ctor="M:JetBrains.Annotations.AssertionMethodAttribute.#ctor"/>
-    <attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
-      <argument>condition:false=&gt;halt</argument>
-    </attribute>
     <attribute ctor="M:JetBrains.Annotations.StringFormatMethodAttribute.#ctor(System.String)">
       <argument>format</argument>
     </attribute>

--- a/JetBrains.ExternalAnnotations.nuspec
+++ b/JetBrains.ExternalAnnotations.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
   <metadata>
     <id>JetBrains.ExternalAnnotations</id>
-    <version>10.2.167</version>
+    <version>10.2.168</version>
     <authors>JetBrains</authors>
     <owners>JetBrains</owners>
     <projectUrl>https://github.com/JetBrains/ExternalAnnotations</projectUrl>


### PR DESCRIPTION
Remove ContractAnnotationAttribute from unity asseertions: RIDER-130566
```    
<attribute ctor="M:JetBrains.Annotations.ContractAnnotationAttribute.#ctor(System.String)">
      <argument>condition:true=&gt;halt</argument>
</attribute>
```